### PR TITLE
Fix "FOLDER" column Kaleidoscope compatibility

### DIFF
--- a/PyHa/IsoAutio.py
+++ b/PyHa/IsoAutio.py
@@ -792,7 +792,7 @@ def kaleidoscope_conversion(df):
     Returns:
         Pandas Dataframe compatible with Kaleidoscope.
     """
-    kaleidoscope_df = [df["FOLDER"], df["IN FILE"], df["CHANNEL"],
+    kaleidoscope_df = [df["FOLDER"].str.rstrip("/\\"), df["IN FILE"], df["CHANNEL"],
                        df["OFFSET"], df["DURATION"], df["MANUAL ID"]]
     headers = ["FOLDER", "IN FILE", "CHANNEL",
                "OFFSET", "DURATION", "MANUAL ID"]


### PR DESCRIPTION
Fixes UCSD-E4E/PyHa#96. Strips final forward slash or backslash from "FOLDER" column input for the kaleidoscope_conversion function.