### PR TITLE
Updating docs for multi-class labeling functions

### DIFF
--- a/PyHa/statistics.py
+++ b/PyHa/statistics.py
@@ -164,10 +164,6 @@ def automated_labeling_statistics(
     examining the efficacy of the automated labelling system compared to the
     human labels for multiple clips.
 
-    Calls bird_local_scores on corresponding audio clips to generate the
-    efficacy statistics for one specific clip which is then all put into one
-    dataframe of statistics for multiple audio clips.
-
     Args:
         automated_df (Dataframe)
             - Dataframe of automated labels of multiple clips.

--- a/PyHa/statistics.py
+++ b/PyHa/statistics.py
@@ -41,7 +41,7 @@ def annotation_duration_statistics(df):
 
 def clip_general(automated_df, human_df):
     """
-    Function to generate a dataframe with statistics relating to the efficiency
+    Function to generate a dataframe with statistics relating to the efficacy
     of the automated label compared to the human label.
     These statistics include true positive, false positive, false negative,
     true negative, union, precision, recall, F1, and Global IoU. For general
@@ -177,9 +177,20 @@ def automated_labeling_statistics(
 
         stats_type (String)
             - String that determines which type of statistics are of interest
+            - options: "IoU", "general" 
+                - "IoU"
+                    - Compares the intersection over union of automated annotations
+                      with respect to manual annotations for individual clips.
+                - "general"
+                    - Consolidates all automated annotations and compares them to all of
+                      the manual annotations that have been consolidated across a clip.
+            - default: "IoU"
 
         threshold (Float)
-            - Defines a threshold for certain types of statistics such as
+            - Defines a threshold for certain types of statistics such as an
+            IoU threshold for determining true positives, false positives, and
+            false negatives.
+            - default: 0.5
 
     Returns:
         Dataframe of statistics comparing automated labels and human labels for
@@ -230,8 +241,8 @@ def global_dataset_statistics(statistics_df, manual_id = "bird"):
               returned by the function automated_labelling_statistics.
         manual_id (String)
             - String to control the "MANUAL ID" column of the csv file
-            format that is used in PyHa. Defaulted to "bird" since the
-            package started out with binary bird classification.
+              format that is used in PyHa. Defaulted to "bird" since the
+              package started out with binary bird classification.
 
     Returns:
         Dataframe of global statistics for the multiple audio clips' labelling.
@@ -375,7 +386,8 @@ def matrix_IoU_Scores(IoU_Matrix, manual_df, threshold):
 
         threshold (float)
             - IoU threshold for determining true positives, false
-                            positives, and false negatives.
+              positives, and false negatives.
+            - default: 0.5
 
     Returns:
         Dataframe of clip statistics such as True Positive, False Negative,
@@ -595,6 +607,11 @@ def global_statistics(statistics_df, manual_id = 'N/A'):
     Args:
         statistics_df (Dataframe)
             - Dataframe of matrix IoU scores for multiple clips.
+        
+        manual_id (String)
+            - String to control the "MANUAL ID" column of the csv file
+              format that is used in PyHa.
+            - default: "N/A"
 
     Returns:
         Dataframe of global IoU statistics which include the number of true
@@ -692,11 +709,20 @@ def clip_statistics(
         
         stats_type (String)
             - String that determines which type of statistics are of interest
-        
+            - options: "IoU", "general" 
+                - "IoU"
+                    - Compares the intersection over union of automated annotations
+                      with respect to manual annotations for individual clips.
+                - "general"
+                    - Consolidates all automated annotations and compares them to all of
+                      the manual annotations that have been consolidated across a clip.
+            - default: "IoU"
+
         threshold (Float)
             - Defines a threshold for certain types of statistics such as an
-            IoU threshold for determining true positives, false positives, and
-            false negatives.
+              IoU threshold for determining true positives, false positives, and
+              false negatives.
+            - default: 0.5
     
     Returns: 
         Dataframe with clip overlap statistics comparing automated and human 
@@ -738,7 +764,7 @@ def class_statistics(clip_statistics):
     Args: 
         clip_statistics (Dataframe)
             - Dataframe of multi-class statistics values for audio clips as 
-            returned by the function clip_statistics.
+              returned by the function clip_statistics.
     
     Returns:
         Dataframe of global efficacy statistics for multiple classes.

--- a/PyHa/statistics.py
+++ b/PyHa/statistics.py
@@ -161,11 +161,11 @@ def automated_labeling_statistics(
     """
     Function that will allow users to easily pass in two dataframes of manual
     labels and automated labels, and a dataframe is returned with statistics
-    examining the efficiency of the automated labelling system compared to the
+    examining the efficacy of the automated labelling system compared to the
     human labels for multiple clips.
 
     Calls bird_local_scores on corresponding audio clips to generate the
-    efficiency statistics for one specific clip which is then all put into one
+    efficacy statistics for one specific clip which is then all put into one
     dataframe of statistics for multiple audio clips.
 
     Args:
@@ -221,7 +221,7 @@ def automated_labeling_statistics(
 
 def global_dataset_statistics(statistics_df, manual_id = "bird"):
     """
-    Function that takes in a dataframe of efficiency statistics for multiple
+    Function that takes in a dataframe of efficacy statistics for multiple
     clips and outputs their global values.
 
     Args:
@@ -671,11 +671,37 @@ def dataset_Catch(automated_df, manual_df):
     return manual_df_with_Catch
 
 
+def clip_statistics(
+        automated_df,
+        manual_df, 
+        stats_type = "IoU", 
+        threshold = 0.5):
+    """
+    Function to generate a dataframe containing efficacy statistics of automated
+    labeling compared to human labels for multiple classes.
 
-# Goes through each class, measuring how effective the labels are in each clip
-def clip_statistics(automated_df,manual_df, stats_type = "IoU", threshold = 0.5):
-    # Creating identifying the overlapping classes between the two sets of dataframes
+    Calls automated_labeling_statistics on individual classes to identify
+    the overlapping human and automated labels, then concats the dataframes.
+
+    Args: 
+        automated_df (Dataframe)
+            - Dataframe of automated labels for multiple classes.
+
+        manual_df (Dataframe)
+            - Dataframe of human labels for multiple classes.
+        
+        stats_type (String)
+            - String that determines which type of statistics are of interest
+        
+        threshold (Float)
+            - Defines a threshold for certain types of statistics such as an
+            IoU threshold for determining true positives, false positives, and
+            false negatives.
     
+    Returns: 
+        Dataframe with clip overlap statistics comparing automated and human 
+        labeling for multiple classes.
+    """
     # Creating a list of classes from the automated dataframe
     automated_class_list = automated_df["MANUAL ID"].to_list()
     automated_class_list = list(dict.fromkeys(automated_class_list))
@@ -703,6 +729,20 @@ def clip_statistics(automated_df,manual_df, stats_type = "IoU", threshold = 0.5)
     return clip_statistics
 
 def class_statistics(clip_statistics):
+    """
+    Function that takes in a dataframe of efficacy statistics for multiple 
+    classes and outputs global efficacy values for each class.
+
+    Calls global_statistics on individual classes, then concats the dataframes.
+
+    Args: 
+        clip_statistics (Dataframe)
+            - Dataframe of multi-class statistics values for audio clips as 
+            returned by the function clip_statistics.
+    
+    Returns:
+        Dataframe of global efficacy statistics for multiple classes.
+    """
     # Initializing the output dataframe
     class_statistics = pd.DataFrame()
     # creating a list of the unique classes being passed in.
@@ -717,5 +757,5 @@ def class_statistics(clip_statistics):
         else:
             temp_df = global_statistics(class_df, manual_id = class_)
             class_statistics = class_statistics.append(temp_df)
-        class_statistics.reset_index(inplace=True,drop=True)
-        return class_statistics
+    class_statistics.reset_index(inplace=True,drop=True)
+    return class_statistics

--- a/README.md
+++ b/README.md
@@ -326,22 +326,31 @@ This function returns a dataframe of human labels with a column for the catch va
 
 Usage: `dataset_Catch(automated_df, manual_df)`
 
-<!-- Need to be updated -->
-### [`dataset_IoU_Statistics`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
+### [`clip_statistics`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
 *Found in [`statistics.py`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)*
-
-*The description for this function has not yet been updated* 
 
 | Parameter | Type |  Description |
 | --- | --- | --- |
-| `automated_df` | Dataframe | Dataframe of automated labels for one clip |
-| `human_df` | Dataframe | Dataframe of human labels for one clip. |
-| `threshold` | float | Defines a threshold for certain types of statistics |
+| `automated_df` | Dataframe | Dataframe of automated labels for multiple classes. |
+| `human_df` | Dataframe | Dataframe of human labels for multiple classes. |
+| `stats_type` | String | String that determines which statistis are of interest. |
+| `threshold` | float | Defines a threshold for certain types of statistics. |
 
-*The return for this function is not yet specified*
+This function returns a dataframe with clip overlap statistics comparing automated and human labeling for multiple classes
 
-Usage: `dataset_IoU_Statistics(automated_df, manual_df, threshold)`
- 
+Usage: `clip_statistics(automated_df, manual_df, stats_type, threshold)`
+
+### [`class_statistics`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
+*Found in [`statistics.py`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)*
+
+| Parameter | Type |  Description |
+| --- | --- | --- |
+| `clip_statistics` | Dataframe | Dataframe of multi-class statistics values for audio clips as returned by the function clip_statistics. |
+
+This function returns a dataframe of global efficacy values for multiple classes.
+
+Usage: `class_statistics(clip_statistics)`
+
 </details>
  
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ Usage: `dataset_Catch(automated_df, manual_df)`
 
 This function returns a dataframe with clip overlap statistics comparing automated and human labeling for multiple classes
 
+The `stats_type` parameter can be set as follows: 
+| Name | Description |
+| --- | --- |
+|`"IoU"`| Default. Compares the intersection over union of automated annotations with respect to manual annotations for individual clips. | 
+|`"general"` | Consolidates all automated annotations and compares them to all of the manual annotations that have been consolidated across a clip. |
+
 Usage: `clip_statistics(automated_df, manual_df, stats_type, threshold)`
 
 ### [`class_statistics`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ This function returns a dataframe of statistics comparing automated labels and h
 The `stats_type` parameter can be set as follows: 
 | Name | Description |
 | --- | --- |
-|`"IoU"`| Default. Compares the intersection over union of automated annotationswith respect to manual annotations for individual clips. | 
+|`"IoU"`| Default. Compares the intersection over union of automated annotations with respect to manual annotations for individual clips. | 
 |`"general"` | Consolidates all automated annotations and compares them to all of the manual annotations that have been consolidated across a clip. |
 
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The `threshold_type` parameter can be: median, mean, average, standard deviation
 
 The remaining parameters are floats representing their respective values. 
 
-<!-- IsoAudio.py file -->
+<!-- IsoAutio.py file -->
 
 <details>
  <summary>IsoAutio.py files</summary>
@@ -213,10 +213,10 @@ This function returns a Pandas Dataframe containing count, mean, mode, standard 
 
 Usage: `annotation_duration_statistics(df)`
 
-### [`bird_label_scores`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
+### [`clip_general`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
 *Found in [`statistics.py`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)*
 
-This function to generates a dataframe with statistics relating to the efficiency of the automated label compared to the human label. These statistics include true positive, false positive, false negative, true negative, union, precision, recall, F1, and Global IoU for general clip overlap.
+This function generates a dataframe with statistics relating to the efficiency of the automated label compared to the human label. These statistics include true positive, false positive, false negative, true negative, union, precision, recall, F1, and Global IoU for general clip overlap.
 
 | Parameter | Type |  Description |
 | --- | --- | --- |
@@ -225,12 +225,12 @@ This function to generates a dataframe with statistics relating to the efficienc
 
 This function returns a dataframe with general clip overlap statistics comparing the automated and human labeling. 
 
-Usage: `bird_label_scores(automated_df, human_df)`
+Usage: `clip_general(automated_df, human_df)`
 
 ### [`automated_labeling_statistics`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
 *Found in [`statistics.py`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)*
 
-This function allows users to easily pass in two dataframes of manual labels and automated labels, and returns a dataframe with statistics examining the efficiency of the automated labelling system compared to the human labels for multiple clips. It calls `bird_local_scores` on corresponding audio clips to generate the efficiency statistics for one specific clip which is then all put into one dataframe of statistics for multiple audio clips.
+This function allows users to easily pass in two dataframes of manual labels and automated labels, and returns a dataframe with statistics examining the efficiency of the automated labelling system compared to the human labels for multiple clips. 
 
 | Parameter | Type |  Description |
 | --- | --- | --- |
@@ -240,6 +240,13 @@ This function allows users to easily pass in two dataframes of manual labels and
 | `threshold` | float | Defines a threshold for certain types of statistics |
 
 This function returns a dataframe of statistics comparing automated labels and human labels for multiple clips. 
+
+The `stats_type` parameter can be set as follows: 
+| Name | Description |
+| --- | --- |
+|`"IoU"`| Default. Compares the intersection over union of automated annotationswith respect to manual annotations for individual clips. | 
+|`"general"` | Consolidates all automated annotations and compares them to all of the manual annotations that have been consolidated across a clip. |
+
 
 Usage: `automated_labeling_statistics(automated_df, manual_df, stats_type, threshold)`
 
@@ -278,8 +285,8 @@ This function takes in the manual and automated labels for a clip and outputs Io
 | Parameter | Type |  Description |
 | --- | --- | --- |
 | `IoU_Matrix`  | arr | (human label count) x (automated label count) matrix where each row contains the IoU of each automated annotation with respect to a human label. |
-| manual_df | Dataframe | Dataframe of human labels for an audio clip. |
-| threshold | float | IoU threshold for determining true positives, false positives, and false negatives. | 
+| `manual_df `| Dataframe | Dataframe of human labels for an audio clip. |
+| `threshold` | float | IoU threshold for determining true positives, false positives, and false negatives. | 
 
 This function returns a dataframe of clip statistics such as True Positive, False Negative, False Positive, Precision, Recall, and F1 values for an audio clip.
 
@@ -299,7 +306,7 @@ This function returns a Numpy Array of statistics regarding the amount of overla
 
 Usage: `clip_catch(automated_df,manual_df)`
 
-### [`global_IoU_Statistics`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
+### [`global_statistics`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
 *Found in [`statistics.py`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)*
 
 This function takes the output of dataset_IoU Statistics and outputs a global count of true positives and false positives, as well as computes the precision, recall, and f1 metrics across the dataset.
@@ -310,7 +317,7 @@ This function takes the output of dataset_IoU Statistics and outputs a global co
 
 This function returns a dataframe of global IoU statistics which include the number of true positives, false positives, and false negatives. Contains Precision, Recall, and F1 metrics as well
 
-Usage: `global_IoU_Statistics(statistics_df)`
+Usage: `global_statistics(statistics_df)`
 
 ### [`dataset_Catch`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)
 *Found in [`statistics.py`](https://github.com/UCSD-E4E/PyHa/blob/main/PyHa/statistics.py)*
@@ -341,7 +348,7 @@ This function returns a dataframe with clip overlap statistics comparing automat
 The `stats_type` parameter can be set as follows: 
 | Name | Description |
 | --- | --- |
-|`"IoU"`| Default. Compares the intersection over union of automated annotations with respect to manual annotations for individual clips. | 
+|`"IoU"`| Default. Compares the intersection over union of automated annotationswith respect to manual annotations for individual clips. | 
 |`"general"` | Consolidates all automated annotations and compares them to all of the manual annotations that have been consolidated across a clip. |
 
 Usage: `clip_statistics(automated_df, manual_df, stats_type, threshold)`
@@ -559,7 +566,7 @@ stats_df = automated_labeling_statistics(automated_df,manual_df,stats_type = "Io
 
 ### Function that takes the output of dataset_IoU Statistics and ouputs a global count of true positives and false positives, as well as computing common metrics across the dataset
 ```python
-global_stats_df = global_IoU_Statistics(stats_df)
+global_stats_df = global_statistics(stats_df)
 ```
 ![image](https://user-images.githubusercontent.com/44332326/127575798-f84540ea-5121-4e7a-83c4-4ca5ad02e9d0.png)
 


### PR DESCRIPTION
#97 Creates PEP8 docstrings for the `clip_statistics` and `class_statistics` functions in statistics.py. Also updates the README statistics.py section.