### PR TITLE
Visualize multiple categories

### DIFF
--- a/PyHa/visualizations.py
+++ b/PyHa/visualizations.py
@@ -89,35 +89,47 @@ def spectrogram_graph(
     axs.set_ylim(0, 22050)
     axs.grid(which='major', linestyle='-')
 
+    colors = ['b','g','r','c','m','y']
+    clen = len(colors)
     # if automated_df is not None:
     if not automated_df.empty:
         ndx = 0
+        color = 0
+        label_colors = {}
         label_list = []
         for row in automated_df.index:
             #Check if new label needs to be made for this group
+            #If so, make new label and assign new color to label
             annotation = premade_annotations_df["MANUAL ID"][row]
             if(annotation not in label_list):
                 ndx=0
+                color+=1
                 label_list.append(annotation)
+                label_colors.update({annotation : colors[color%clen]})
             else:
                 ndx=1
 
             minval = automated_df["OFFSET"][row]
             maxval = automated_df["OFFSET"][row] + \
                 automated_df["DURATION"][row]
-            axs.axvspan(xmin=minval, xmax=maxval, facecolor="yellow",
+            axs.axvspan(xmin=minval, xmax=maxval, facecolor=label_colors[annotation],
                            alpha=0.4, label="_" * ndx + annotation)
 
     # Adding in the optional premade annotations from a Pandas DataFrame
     if not premade_annotations_df.empty:
         ndx = 0
+        color = 0
+        label_colors = {}
         label_list = []
         for row in premade_annotations_df.index:
             #Check if new label needs to be made for this group
+            #If so, make new label and assign new color to label
             annotation = premade_annotations_df["MANUAL ID"][row]
             if(annotation not in label_list):
                 ndx=0
+                color+=1
                 label_list.append(annotation)
+                label_colors.update({annotation : colors[color%clen]})
             else:
                 ndx=1
 
@@ -127,7 +139,7 @@ def spectrogram_graph(
             axs.axvspan(
                 xmin=minval,
                 xmax=maxval,
-                facecolor="red",
+                facecolor=label_colors[annotation],
                 alpha=0.4,
                 label="_" *
                 ndx +

--- a/PyHa/visualizations.py
+++ b/PyHa/visualizations.py
@@ -92,18 +92,35 @@ def spectrogram_graph(
     # if automated_df is not None:
     if not automated_df.empty:
         ndx = 0
+        label_list = []
         for row in automated_df.index:
+            #Check if new label needs to be made for this group
+            annotation = premade_annotations_df["MANUAL ID"][row]
+            if(annotation not in label_list):
+                ndx=0
+                label_list.append(annotation)
+            else:
+                ndx=1
+
             minval = automated_df["OFFSET"][row]
             maxval = automated_df["OFFSET"][row] + \
                 automated_df["DURATION"][row]
             axs.axvspan(xmin=minval, xmax=maxval, facecolor="yellow",
-                           alpha=0.4, label="_" * ndx + "Automated Labels")
-            ndx += 1
+                           alpha=0.4, label="_" * ndx + annotation)
 
     # Adding in the optional premade annotations from a Pandas DataFrame
     if not premade_annotations_df.empty:
         ndx = 0
+        label_list = []
         for row in premade_annotations_df.index:
+            #Check if new label needs to be made for this group
+            annotation = premade_annotations_df["MANUAL ID"][row]
+            if(annotation not in label_list):
+                ndx=0
+                label_list.append(annotation)
+            else:
+                ndx=1
+
             minval = premade_annotations_df["OFFSET"][row]
             maxval = premade_annotations_df["OFFSET"][row] + \
                 premade_annotations_df["DURATION"][row]
@@ -114,8 +131,7 @@ def spectrogram_graph(
                 alpha=0.4,
                 label="_" *
                 ndx +
-                premade_annotations_label)
-            ndx += 1
+                annotation)
     axs.legend()
 
     # save graph


### PR DESCRIPTION
Closes #135

These changes allow the `visualize_spectrogram` function to graph multiple different categories, assigning each category a different label and color.  All actual changes are done in the `spectrogram_graph` function, since `visualize_spectrogram` just calls that to draw the final graph. If there are more than six categories, colors will start being re-used.


Tested using a modified version of the Screaming Piha test dataset provided on here. Here are some results from different calls of the function, to make sure my changes matched the intended results:

`spectrogram_visualization(clip_path, premade_annotations_df = manual_df[manual_df["IN FILE"] == "ScreamingPiha2.wav"],premade_annotations_label = "Piha Human Labels")`
![image](https://user-images.githubusercontent.com/114893351/207875937-f872823d-16a4-4f5c-a157-a0df407938a7.png)

`spectrogram_visualization(clip_path,automated_df = True, isolation_parameters = isolation_parameters)`
![image](https://user-images.githubusercontent.com/114893351/207876204-6a9cb3c4-44f6-4ba9-90bc-d40efefee691.png)

`spectrogram_visualization(clip_path,automated_df = True,isolation_parameters=isolation_parameters,premade_annotations_df = manual_df[manual_df["IN FILE"] == "ScreamingPiha2.wav"])`
![image](https://user-images.githubusercontent.com/114893351/207876434-874daa02-cc80-4796-a3eb-5260101dbc6e.png)
